### PR TITLE
manual Serialize for AssetId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadex-primitives"
-version = "0.3.0"
+version = "0.5.0"
 authors = ["Gautham J <Gauthamastro@gmail.com>"]
 edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadex-primitives"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Gautham J <Gauthamastro@gmail.com>"]
 edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadex-primitives"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Gautham J <Gauthamastro@gmail.com>"]
 edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -18,12 +18,12 @@
 
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+use serde::de::{EnumAccess, Error, MapAccess, SeqAccess, Visitor};
+use serde::{de, Deserializer, Serializer};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
 use std::fmt::{Display, Formatter};
-use serde::{de, Deserializer, Serializer};
-use serde::de::{EnumAccess, Error, MapAccess, SeqAccess, Visitor};
 
 /// Enumerated asset on chain
 #[derive(
@@ -52,10 +52,13 @@ pub enum AssetId {
 }
 
 impl Serialize for AssetId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
         match *self {
             AssetId::asset(i) => serializer.serialize_u128(i),
-            AssetId::polkadex => serializer.serialize_unit_variant("polkadex", 1, "polkadex"),
+            AssetId::polkadex => serializer.serialize_unit_variant("asset_id", 1, "polkadex"),
         }
     }
 }

--- a/src/egress.rs
+++ b/src/egress.rs
@@ -9,7 +9,7 @@ use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Encode, Decode, TypeInfo, Debug)]
+#[derive(Clone, Encode, Decode, TypeInfo, Debug, PartialEq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum EgressMessages {
     RegisterEnclave(BoundedVec<u8, UnpaddedReportSize>),


### PR DESCRIPTION
Manual `serialize` implementation for `AssetId` - part of the fix for [Orderbook's #326](https://github.com/Polkadex-Substrate/orderbook/issues/326)