### PR TITLE
052

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "polkadex-primitives"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Gautham J <Gauthamastro@gmail.com>"]
-edition = "2018"
+edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadex-primitives"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Gautham J <Gauthamastro@gmail.com>"]
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/ocex.rs
+++ b/src/ocex.rs
@@ -1,4 +1,4 @@
-use crate::assets::AssetId;
+use crate::assets::{AssetId, HashAssetId};
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::traits::Get;
 use frame_support::BoundedVec;
@@ -18,7 +18,7 @@ pub struct AccountInfo<Account, Balance: Zero + Clone, ProxyLimit: Get<u32>> {
     pub main_account: Account,
     pub proxies: BoundedVec<Account, ProxyLimit>,
     pub nonce: u32,
-    pub balances: BTreeMap<AssetId, (Balance, Balance)>,
+    pub balances: BTreeMap<HashAssetId, (Balance, Balance)>,
     /// Trading Fee config
     pub fee_config: FeeConfig<Balance>,
 }


### PR DESCRIPTION
* Introduced `HashAssetId` to be used as key in `BTreeMap`s to avoid serde bug
* Regular `AssetId` should be used in other cases
* Easily convertable with `.into()` for both