### PR TITLE
053 no std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "polkadex-primitives"
-version = "0.1.0"
+version = "0.9.19"
 authors = ["Gautham J <Gauthamastro@gmail.com>"]
-edition = "2018"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", optional = true }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.1.1", default-features = false, features = ["derive"] }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -56,3 +56,68 @@ impl Display for AssetId {
         }
     }
 }
+
+#[derive(
+    Encode,
+    Decode,
+    Copy,
+    Clone,
+    Hash,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    RuntimeDebug,
+    TypeInfo,
+    MaxEncodedLen,
+)]
+#[cfg_attr(feature = "std", derive(Deserialize))]
+#[serde(tag = "asset_id")]
+pub enum HashAssetId {
+    /// Generic enumerated assed
+    /// Range 0 - 0x00000000FFFFFFFF (2^32)-1 is reserved for protected tokens
+    /// the values under 1000 are used for ISO 4217 Numeric Curency codes
+    asset(u128),
+    /// PDEX the native currency of the chain
+    polkadex,
+}
+
+#[cfg(not(feature = "std"))]
+impl Serialize for HashAssetId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            HashAssetId::asset(i) => serializer.serialize_u128(i),
+            HashAssetId::polkadex => serializer.serialize_unit_variant("asset_id", 1, "polkadex"),
+        }
+    }
+}
+
+impl Display for HashAssetId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> sp_std::fmt::Result {
+        match self {
+            HashAssetId::polkadex => write!(f, "PDEX"),
+            HashAssetId::asset(id) => write!(f, "{:?}", id),
+        }
+    }
+}
+
+impl Into<AssetId> for HashAssetId {
+    fn into(self) -> AssetId {
+        match self {
+            HashAssetId::polkadex => AssetId::polkadex,
+            HashAssetId::asset(n) => AssetId::asset(n)
+        }
+    }
+}
+
+impl Into<HashAssetId> for AssetId {
+    fn into(self) -> HashAssetId {
+        match self {
+            AssetId::polkadex => HashAssetId::polkadex,
+            AssetId::asset(n) => HashAssetId::asset(n)
+        }
+    }
+}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -7,7 +7,7 @@ use sp_std::collections::btree_map::BTreeMap;
 use codec::{Decode, Encode,MaxEncodedLen};
 use frame_support::traits::Get;
 use scale_info::TypeInfo;
-use crate::{AssetId, Balance};
+use crate::AssetId;
 
 /// Provides maximum number of accounts possible in enclave data dump
 pub struct AccountInfoDumpLimit;


### PR DESCRIPTION
* `HashAssetId` inclusion from main branch
* rust edition bumped to 2021
* version set to `0.9.19` to reflect usecase