### PR TITLE
fix: added btreemap for primitives

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -35,18 +35,18 @@ pub struct Fees<Balance: Zero + Clone>{
 #[derive(Clone, Encode, Decode, TypeInfo, Debug)]
 // #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[scale_info(skip_type_params(SnapshotAccLimit, WithdrawalLimit,AssetsLimit ))]
-pub struct EnclaveSnapshot<Account, Balance: Zero + Clone, WithdrawalLimit: Get<u32>, AssetsLimit: Get<u32>> {
+pub struct EnclaveSnapshot<Account: Ord, Balance: Zero + Clone, WithdrawalLimit: Get<u32>, AssetsLimit: Get<u32>> {
     /// Serial number of snapshot.
     pub snapshot_number: u32,
     /// Hash of the balance snapshot dump made by enclave. ( dump contains all the accounts in enclave )
     pub merkle_root: H256,
     /// Withdrawals
-    pub withdrawals: BoundedVec<Withdrawal<Account, Balance>, WithdrawalLimit>,
+    pub withdrawals: BTreeMap<Account, BoundedVec<Withdrawal<Account, Balance>, WithdrawalLimit>>,
     /// Fees collected by the operator
     pub fees: BoundedVec<Fees<Balance>,AssetsLimit>
 }
 
-impl<Account, Balance: Zero + Clone, WithdrawalLimit: Get<u32>, AssetsLimit: Get<u32>> PartialEq
+impl<Account: Ord, Balance: Zero + Clone, WithdrawalLimit: Get<u32>, AssetsLimit: Get<u32>> PartialEq
     for EnclaveSnapshot<Account, Balance, WithdrawalLimit,AssetsLimit>
 {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
This will add btree map in snapshot primitives 