### PR TITLE
fix: add event_id to withdrawal struct

### DIFF
--- a/src/withdrawal.rs
+++ b/src/withdrawal.rs
@@ -11,4 +11,5 @@ pub struct Withdrawal<AccountId, Balance> {
     pub main_account: AccountId,
     pub amount: Balance,
     pub asset: AssetId,
+    pub event_id: u64
 }


### PR DESCRIPTION
Update the withdrawal struct to include event_id 