### PR TITLE
fix: add event_id to withdrawal struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,3 +115,12 @@ impl Get<u32> for WithdrawalLimit {
         500
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct OnChainEventsLimit;
+impl Get<u32> for OnChainEventsLimit {
+    fn get() -> u32 {
+        500
+    }
+}

--- a/src/ocex.rs
+++ b/src/ocex.rs
@@ -78,8 +78,8 @@ pub struct TradingPairConfig<Balance> {
 
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum OnChainEvents{
-	OrderBookWithdrawalClaimed(u64, u32, u64), 
+pub enum OnChainEvents<AccountId>{
+	OrderBookWithdrawalClaimed(u64, u32, AccountId), 
     GetStorage(Pallet, StorageItem, u32)
 }
 

--- a/src/ocex.rs
+++ b/src/ocex.rs
@@ -8,6 +8,8 @@ use sp_std::collections::btree_map::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::fees::FeeConfig;
+use crate::WithdrawalLimit;
+use crate::withdrawal::Withdrawal;
 use sp_runtime::traits::Zero;
 
 #[derive(Clone, Encode, Decode, TypeInfo, Debug)]
@@ -78,8 +80,8 @@ pub struct TradingPairConfig<Balance> {
 
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum OnChainEvents<AccountId>{
-	OrderBookWithdrawalClaimed(u64, u32, AccountId), 
+pub enum OnChainEvents<AccountId, Balance>{
+	OrderBookWithdrawalClaimed(u32, AccountId, BoundedVec<Withdrawal<AccountId, Balance>, WithdrawalLimit>), 
     GetStorage(Pallet, StorageItem, u32)
 }
 
@@ -93,4 +95,4 @@ pub enum Pallet {
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum StorageItem{
     Withdrawal
-} 
+}

--- a/src/ocex.rs
+++ b/src/ocex.rs
@@ -75,3 +75,22 @@ pub struct TradingPairConfig<Balance> {
     pub min_depth: Balance,
     pub max_spread: Balance,
 }
+
+#[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum OnChainEvents{
+	OrderBookWithdrawalClaimed(u64, u32, u64), 
+    GetStorage(Pallet, StorageItem, u32)
+}
+
+#[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum Pallet {
+    OCEX
+} 
+
+#[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum StorageItem{
+    Withdrawal
+} 

--- a/src/withdrawal.rs
+++ b/src/withdrawal.rs
@@ -11,4 +11,5 @@ pub struct Withdrawal<AccountId, Balance> {
     pub main_account: AccountId,
     pub amount: Balance,
     pub asset: AssetId,
+    pub event_id: u64,
 }


### PR DESCRIPTION
This PR adds `event_id` to the withdrawal struct