### PR TITLE
fix: add fees to withdrawal struct

### DIFF
--- a/src/withdrawal.rs
+++ b/src/withdrawal.rs
@@ -12,5 +12,5 @@ pub struct Withdrawal<AccountId, Balance> {
     pub amount: Balance,
     pub asset: AssetId,
     pub event_id: u64,
-    pub fees: u128,
+    pub fees: Balance,
 }

--- a/src/withdrawal.rs
+++ b/src/withdrawal.rs
@@ -12,4 +12,5 @@ pub struct Withdrawal<AccountId, Balance> {
     pub amount: Balance,
     pub asset: AssetId,
     pub event_id: u64,
+    pub fees: u128,
 }


### PR DESCRIPTION
Adds `pub fees: u128` to `Withdrawal` struct