### PR TITLE
add operational_status flag to tradingPairConfig

### DIFF
--- a/src/ocex.rs
+++ b/src/ocex.rs
@@ -74,6 +74,7 @@ pub struct TradingPairConfig<Balance> {
     pub min_qty: Balance,
     pub max_qty: Balance,
     pub qty_step_size: Balance,
+    pub operational_status: bool, //will be true if the trading pair is enabled on the orderbook.
 }
 
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]


### PR DESCRIPTION
The operational_status flag is used to determine if the the tradingpair can be traded on the orderbook. this flag removes the additional storage item tradignPairStatus from the node side.