### PR TITLE
refactor: merkle_root to snapshot_hash in EnclaveSnapshot

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -43,7 +43,7 @@ pub struct EnclaveSnapshot<Account: Ord, Balance: Zero + Clone, WithdrawalLimit:
     /// Serial number of snapshot.
     pub snapshot_number: u32,
     /// Hash of the balance snapshot dump made by enclave. ( dump contains all the accounts in enclave )
-    pub merkle_root: H256,
+    pub snapshot_hash: H256,
     /// Withdrawals
     pub withdrawals: BoundedBTreeMap<Account, BoundedVec<Withdrawal<Account, Balance>, WithdrawalLimit>, SnapshotAccLimit>,
     /// Fees collected by the operator
@@ -63,7 +63,7 @@ EnclaveSnapshot<Account, Balance, WithdrawalLimit, AssetsLimit, SnapshotAccLimit
     fn try_from(value: EnclaveSnapshotStd<Account, Balance, WithdrawalLimit, AssetsLimit>) -> Result<Self, Self::Error> {
         Ok(EnclaveSnapshot {
             snapshot_number: value.snapshot_number,
-            merkle_root: value.merkle_root,
+            snapshot_hash: value.merkle_root,
             withdrawals: BoundedBTreeMap::try_from(value.withdrawals)?,
             fees: value.fees
         })


### PR DESCRIPTION
This PR changes `merkle_root` to `snapshot_hash` 

Before we merge this PR, We need to ensure that the node is using a tag rather than a branch in all it's primitives dependencies 