### PR TITLE
fix: add base and quote asset precision

### DIFF
--- a/src/assets.rs
+++ b/src/assets.rs
@@ -21,6 +21,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize, Serializer};
+#[cfg(feature = "std")]
 use serde::ser::SerializeStruct;
 use sp_core::RuntimeDebug;
 

--- a/src/ocex.rs
+++ b/src/ocex.rs
@@ -76,6 +76,8 @@ pub struct TradingPairConfig {
     pub max_qty: Decimal,
     pub qty_step_size: Decimal,
     pub operational_status: bool, //will be true if the trading pair is enabled on the orderbook.
+    pub base_asset_precision: u8,
+    pub quote_asset_precision: u8
 }
 
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]


### PR DESCRIPTION
Adds two new fields `base_asset_precision` and `quote_asset_precision` 