### PR TITLE
Add ingress message (node side)

### DIFF
--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -4,6 +4,8 @@ use crate::AssetId;
 use serde::{Deserialize, Serialize};
 
 use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::traits::Get;
+use frame_support::BoundedVec;
 use rust_decimal::Decimal;
 use scale_info::TypeInfo;
 use sp_core::H256;
@@ -34,5 +36,25 @@ pub enum IngressMessages<AccountId> {
     // Latest snapshot (MerkelRoot, snapshot_no)
     LastestSnapshot(H256, u32),
     // Main Acc, Assetid, Amount
-    UnreserveBalance(AccountId, AssetId, Decimal),
+    SetFreeReserveBalanceForAccounts(BoundedVec<HandleBalance<AccountId>, HandleBalanceLimit>)
+}
+
+#[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct HandleBalance<AccountId> {
+    pub main_account: AccountId,
+    pub asset_id: AssetId,
+    pub free: Decimal,
+    pub reserve: Decimal,
+}
+
+#[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct HandleBalanceLimit;
+
+impl Get<u32> for HandleBalanceLimit {
+    //ToDo: Set an arbitrary value to 1000.
+    fn get() -> u32 {
+        1000
+    }
 }

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -46,8 +46,8 @@ pub enum IngressMessages<AccountId> {
 pub struct HandleBalance<AccountId> {
     pub main_account: AccountId,
     pub asset_id: AssetId,
-    pub free: Decimal,
-    pub reserve: Decimal,
+    pub free: u128,
+    pub reserve: u128,
 }
 
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -32,5 +32,7 @@ pub enum IngressMessages<AccountId> {
     // Close Trading Pair
     CloseTradingPair(TradingPairConfig),
     // Latest snapshot (MerkelRoot, snapshot_no)
-    LastestSnapshot(H256, u32)
+    LastestSnapshot(H256, u32),
+    // Main Acc, Assetid, Amount
+    UnreserveBalance(AccountId, AssetId, Decimal),
 }

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -36,7 +36,9 @@ pub enum IngressMessages<AccountId> {
     // Latest snapshot (MerkelRoot, snapshot_no)
     LastestSnapshot(H256, u32),
     //Resetting the balances of Account
-    SetFreeReserveBalanceForAccounts(BoundedVec<HandleBalance<AccountId>, HandleBalanceLimit>)
+    SetFreeReserveBalanceForAccounts(BoundedVec<HandleBalance<AccountId>, HandleBalanceLimit>),
+    // Changing the exchange state in order-book
+    SetExchangeState(bool),
 }
 
 #[derive(Clone, Encode, Decode, MaxEncodedLen, TypeInfo, Debug, PartialEq)]

--- a/src/ingress.rs
+++ b/src/ingress.rs
@@ -35,7 +35,7 @@ pub enum IngressMessages<AccountId> {
     CloseTradingPair(TradingPairConfig),
     // Latest snapshot (MerkelRoot, snapshot_no)
     LastestSnapshot(H256, u32),
-    // Main Acc, Assetid, Amount
+    //Resetting the balances of Account
     SetFreeReserveBalanceForAccounts(BoundedVec<HandleBalance<AccountId>, HandleBalanceLimit>)
 }
 


### PR DESCRIPTION
The Pr adds an ingress message to reset balance. 

Note: This will break the main net runtime the [Tag Pr ](https://github.com/Polkadex-Substrate/Polkadex/pull/566) needs to get merge to main met before merging this PR. 